### PR TITLE
fix error GameProfile name cannot be null

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
    <modelVersion>4.0.0</modelVersion>
    <groupId>com.falyrion.aa</groupId>
    <artifactId>AdvancedArmorStands</artifactId>
-   <version>1.19.0</version>
+   <version>1.19.1</version>
 
    <properties>
       <java.version>17</java.version>
@@ -53,7 +53,6 @@
             <version>1.16-R0.4</version>
             <scope>provided</scope>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/com.mojang/authlib -->
         <dependency>
             <groupId>com.mojang</groupId>
             <artifactId>authlib</artifactId>

--- a/src/main/java/commands/CmdReciveCustomHead.java
+++ b/src/main/java/commands/CmdReciveCustomHead.java
@@ -46,7 +46,7 @@ public class CmdReciveCustomHead implements CommandInterface {
                 // Get texture value
                 String textureValue = getTexture(playerName);
 
-                // Check for sucess
+                // Check for success
                 if (textureValue == null) {
                     String errorMessage = AdvancedArmorStandsMain.getInstance().getMessageString("head_error_01", player.getLocale());
                     player.sendMessage(ChatColor.RED + errorMessage);
@@ -61,7 +61,7 @@ public class CmdReciveCustomHead implements CommandInterface {
                 assert headMeta != null;
 
                 // Set Game Profile
-                GameProfile profile = new GameProfile(UUID.randomUUID(), null);
+                GameProfile profile = new GameProfile(UUID.randomUUID(), "Head_" + playerName);
                 profile.getProperties().put("textures", new Property("textures", textureValue));
 
                 try {

--- a/src/main/java/commands/CmdReciveCustomHead.java
+++ b/src/main/java/commands/CmdReciveCustomHead.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -61,7 +62,8 @@ public class CmdReciveCustomHead implements CommandInterface {
                 assert headMeta != null;
 
                 // Set Game Profile
-                GameProfile profile = new GameProfile(UUID.randomUUID(), "Head_" + playerName);
+                GameProfile profile = new GameProfile(UUID.randomUUID(),
+                        RandomStringUtils.randomAlphabetic(16));
                 profile.getProperties().put("textures", new Property("textures", textureValue));
 
                 try {
@@ -108,7 +110,6 @@ public class CmdReciveCustomHead implements CommandInterface {
         return true;
 
     }
-
 
     public String getTexture (String name) {
         try {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -3,7 +3,7 @@
 # For help or contributions please visit: https://github.com/Falyrion/AdvancedArmorStands
 #
 # DO NOT MODIFY THE VERSION
-version: v.1.19.0.0
+version: v.1.19.1.0
 # ######################################################################################################################
 #
 spawnWithArms: 1

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: AdvancedArmorStands
 author: Falyrion
 description: Easy editing of armor stands and player heads
-version: 1.19.0.0
+version: 1.19.1.0
 api-version: 1.17
 
 main: com.falyrion.aa.AdvancedArmorStandsMain


### PR DESCRIPTION
- I noticed first after updating to 1.21, but it has been like that probably for a long time. I also tested it on my public server